### PR TITLE
[just for reference] using back propagation for crazy fast gradient

### DIFF
--- a/src/VQEdesign.jl
+++ b/src/VQEdesign.jl
@@ -1,6 +1,7 @@
 using Yao, Yao.ConstGate, BitBasis
 using Statistics, Plots
 using KrylovKit: eigsolve
+using QuAlgorithmZoo: autodiff
 
 
 include("paracircuit.jl")
@@ -10,11 +11,11 @@ include("train.jl")
 ising1d = Ising(6; periodic = false, h = 2, J_coupling = 0.8)
 repeat = 1
 ising1dfull = FullConnectStruct(nspins(ising1d), repeat)
-ising1dfullcircuit = get_struct(ising1dfull, CNOT)
+ising1dfullcircuit = get_struct(ising1dfull, CNOT) |> autodiff(:BP)
 ising1dmachine = TrainMachine(hamiltonian(ising1d), ising1dfullcircuit)
 
 ising1dnear = NearestStruct(nspins(ising1d), repeat)
-ising1dnearcircuit = get_struct(ising1dnear, CNOT)
+ising1dnearcircuit = get_struct(ising1dnear, CNOT) |> autodiff(:BP)
 ising1dmachine = TrainMachine(hamiltonian(ising1d), ising1dnearcircuit)
 
 

--- a/src/paracircuit.jl
+++ b/src/paracircuit.jl
@@ -19,6 +19,8 @@ end
 
 @const_gate CZ = mat(control(2, 1, 2=>Z))
 
+rots(n::Int, loc::Int) = chain(n, put(n, loc => rot(G, 0.0)) for G in [X, Y,Z])
+
 function paraEntangler(mode, nqubit::Int, loc1::Int, loc2::Int)
     put(nqubit, (loc1, loc2) => rot(mode, 0.0))
 end
@@ -31,8 +33,8 @@ function get_struct(c::AbsCircuitStructure, mode)
         for i = 1:c.nrepeat
             for j = 1:(c.nqubit - 1)
                 for m = j+1 : c.nqubit
-                    put(c.nqubit, j => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))) |> add!
-                    put(c.nqubit, m => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))) |> add!
+                    rots(c.nqubit, j) |> add!
+                    rots(c.nqubit, m) |> add!
                     paraEntangler(mode, c.nqubit, j, m) |> add!
                 end
             end
@@ -42,15 +44,15 @@ function get_struct(c::AbsCircuitStructure, mode)
 #            chain(c.nqubit, put(c.nqubit, loc => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))) for loc = 1:c.nqubit) |> add!
             for i = 1:c.nqubit
                 if i%2 == 1
-                    chain(c.nqubit, chain(put(c.nqubit, l1 => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))), put(c.nqubit, l1 + 1 => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))), paraEntangler(mode, c.nqubit, l1, l1 + 1)) for l1 = 1 : 2 : c.nqubit - 2 * (c.nqubit%2)) |> add!
+                    chain(c.nqubit, chain(rots(c.nqubit, l1), rots(c.nqubit, l1+1), paraEntangler(mode, c.nqubit, l1, l1 + 1)) for l1 = 1 : 2 : c.nqubit - 2 * (c.nqubit%2)) |> add!
                 else
-                    chain(c.nqubit, chain(put(c.nqubit, l2 => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))), put(c.nqubit, l2 + 1 => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))), paraEntangler(mode, c.nqubit, l2, l2 + 1)) for l2 = 2: 2: c.nqubit - 2 * ((c.nqubit+1)%2)) |> add!
+                    chain(c.nqubit, chain(rots(c.nqubit, l2), rots(c.nqubit, l2+1), paraEntangler(mode, c.nqubit, l2, l2 + 1)) for l2 = 2: 2: c.nqubit - 2 * ((c.nqubit+1)%2)) |> add!
                 end
             end
         end
     elseif typeof(c) == NearestStruct
         for i = 1:c.nrepeat
-            chain(c.nqubit, put(c.nqubit, loc => chain(rot(Z, 0.0), rot(X, 0.0), rot(Z, 0.0))) for loc = 1:c.nqubit) |> add!
+            chain(c.nqubit, rots(c.nqubit, loc) for loc = 1:c.nqubit) |> add!
             for j = 1:(c.nqubit-1)
                 chain(c.nqubit, paraEntangler(mode, c.nqubit, j, j + 1)) |> add!
             end


### PR DESCRIPTION
When the number of parameters is large, this will be much faster to use the gradient algorithm in `QualgorithmZoo`. (even for 23 parameters, it has 10 times speed up), but please notice

* It is a back propagation algorithm, so it's complexity is O(N), the original version is O(N^2),
* It is only for classical simulation and can not be compiled to quantum devices,
* It is more restrictive to block types, e.g. `put(4, 3=>chain(Rx(0.5) Ry(0.6)))` is not allowed, but `chain(put(4, 3=>Rx(0.5)), put(4, 3=> Ry(0.6)))` will work,
* This algorithm does not cache intermediate results (traditional BP will do), so is memory efficient.
